### PR TITLE
run_puppet command is changed to 'puppet agent -t' for accurate exit cod...

### DIFF
--- a/lib/rouster/puppet.rb
+++ b/lib/rouster/puppet.rb
@@ -281,7 +281,7 @@ class Rouster
   # ... runs puppet on self, returns nothing
   #
   # currently supports 2 methods of running puppet:
-  #  * master - runs '/sbin/service puppet once -t'
+  #  * master - runs 'puppet agent -t'
   #    * supported options
   #      * expected_exitcode - string/integer/array of acceptable exit code(s)
   #  * masterless - runs 'puppet apply <options>' after determining version of puppet running and adjusting arguments


### PR DESCRIPTION
...es
