### PR TITLE
added support for older vagrant versions

### DIFF
--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -179,7 +179,7 @@ class Rouster
     self._run(sprintf('cd %s; vagrant status %s', File.dirname(@vagrantfile), @name))
 
     # else case here is handled by non-0 exit code
-    if self.get_output().match(/^#{@name}\s*(.*\s?\w+)\s(.+)$/)
+    if self.get_output().match(/^#{@name}\s*(.*\s?\w+)\s?(.+)?$/)
       # $1 = name, $2 = provider
       status = $1
     end


### PR DESCRIPTION
older versions of vagrant dont contain the provider in the output, so make the match optional
