### PR TITLE
crontab can have environment variables

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,10 @@ task :buildgem do
   sh 'gem build rouster.gemspec'
 end
 
+task :clean do
+  sh 'rm /tmp/rouster-*'
+end
+
 task :default do
   sh 'ruby test/basic.rb'
 end

--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -70,6 +70,12 @@ class Rouster
         next if line.match(/^#|^\s+$/)
         elements = line.split("\s")
 
+        if elements.size < 5
+          # this is usually (only?) caused by ENV_VARIABLE=VALUE directives
+          @logger.debug(sprintf('line [%s] did not match format expectations for a crontab entry, skipping', line))
+          next
+        end
+
         command = elements[5..elements.size].join(' ')
 
         res[u] ||= Hash.new

--- a/test/functional/deltas/test_get_crontab.rb
+++ b/test/functional/deltas/test_get_crontab.rb
@@ -127,7 +127,7 @@ class TestDeltasGetCrontab < Test::Unit::TestCase
     @app.run("crontab -u #{user} #{tmp}")
 
     assert_nothing_raised do
-      res = @app.get_crontab('puppet')
+      res = @app.get_crontab(user)
     end
 
     assert_equal(Hash, res.class)
@@ -137,14 +137,16 @@ class TestDeltasGetCrontab < Test::Unit::TestCase
   end
 
   def test_non_matching_lines
-    res = nil
+    res  = nil
+    user = 'root'
+    tmp  = sprintf('/tmp/rouster.tmp.crontab.%s.%s.%s', user, Time.now.to_i, $$)
 
-    tmp = sprintf('/tmp/rouster.tmp.crontab.%s.%s.%s', user. Time.now.to_i, $$)
     @app.run("echo 'PATH=/sbin:/usr/bin:/usr/local/bin' > #{tmp}")
+    @app.run("echo '5 5 * * * echo #{user}' >> #{tmp}")
     @app.run("crontab -u #{user} #{tmp}")
 
     assert_nothing_raised do
-      res = @app.get_crontab('root', false)
+      res = @app.get_crontab(user, false)
     end
 
     assert_equal(Hash, res.class)

--- a/test/functional/deltas/test_get_crontab.rb
+++ b/test/functional/deltas/test_get_crontab.rb
@@ -136,6 +136,22 @@ class TestDeltasGetCrontab < Test::Unit::TestCase
 
   end
 
+  def test_non_matching_lines
+    res = nil
+
+    tmp = sprintf('/tmp/rouster.tmp.crontab.%s.%s.%s', user. Time.now.to_i, $$)
+    @app.run("echo 'PATH=/sbin:/usr/bin:/usr/local/bin' > #{tmp}")
+    @app.run("crontab -u #{user} #{tmp}")
+
+    assert_nothing_raised do
+      res = @app.get_crontab('root', false)
+    end
+
+    assert_equal(Hash, res.class)
+    assert(res.has_key?('echo root'))
+
+  end
+
   def teardown
     @app = nil
   end


### PR DESCRIPTION
  * fix bug causing exception to be thrown if environment variables are set in a crontab
  * add test to cover this behavior

  * add 'clean' task to Rakefile