### PR TITLE
Two fixes in the restart function

### DIFF
--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -360,7 +360,7 @@ class Rouster
     if @ssh.nil? or @ssh.closed?
       begin
         res = self.connect_ssh_tunnel()
-      rescue Rouster::InternalError, Net::SSH::Disconnect => e
+      rescue Rouster::InternalError, Net::SSH::Disconnect. Errno::ECONNREFUSED => e
         res = false
       end
 

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -640,10 +640,13 @@ class Rouster
 
     if wait
       inc = wait.to_i / 10
-      0..wait.each do |e|
+      0.upto(10) do |e|
         @logger.debug(sprintf('waiting for reboot: round[%s], step[%s], total[%s]', e, inc, wait))
-        return true if self.is_available_via_ssh?()
-        sleep inc
+       begin
+         return true if self.is_available_via_ssh?()
+       rescue => ex
+       end
+       sleep inc
       end
 
       return false

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -642,10 +642,7 @@ class Rouster
       inc = wait.to_i / 10
       0.upto(10) do |e|
         @logger.debug(sprintf('waiting for reboot: round[%s], step[%s], total[%s]', e, inc, wait))
-       begin
-         return true if self.is_available_via_ssh?()
-       rescue => ex
-       end
+       return true if self.is_available_via_ssh?()
        sleep inc
       end
 

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -642,8 +642,8 @@ class Rouster
       inc = wait.to_i / 10
       0.upto(10) do |e|
         @logger.debug(sprintf('waiting for reboot: round[%s], step[%s], total[%s]', e, inc, wait))
-       return true if self.is_available_via_ssh?()
-       sleep inc
+        return true if self.is_available_via_ssh?()
+        sleep inc
       end
 
       return false


### PR DESCRIPTION
- iterates more cleanly in 10 steps over allotted time
- catches exceptions in is_available_via_ssh? (specifically, connection refused which can happen before box is fully up)