### PR TITLE
resetting :address expectations in validate_port

### DIFF
--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -360,7 +360,7 @@ class Rouster
     if @ssh.nil? or @ssh.closed?
       begin
         res = self.connect_ssh_tunnel()
-      rescue Rouster::InternalError, Net::SSH::Disconnect, Errno::ECONNREFUSED => e
+      rescue Rouster::InternalError, Net::SSH::Disconnect, Errno::ECONNREFUSED, Errno::ECONNRESET => e
         res = false
       end
 

--- a/lib/rouster/testing.rb
+++ b/lib/rouster/testing.rb
@@ -581,7 +581,7 @@ class Rouster
 
         when :address
           lr = Array.new
-          if ports[expectations[:protocol]][number].has_key?(:address)
+          if ports[expectations[:protocol]][number]
             addresses = ports[expectations[:protocol]][number][:address]
             addresses.each_key do |address|
               lr.push(address.eql?(v.to_s))

--- a/lib/rouster/testing.rb
+++ b/lib/rouster/testing.rb
@@ -581,13 +581,17 @@ class Rouster
 
         when :address
           lr = Array.new
-          addresses = ports[expectations[:protocol]][number][:address]
-          addresses.each_key do |address|
-            lr.push(address.eql?(v.to_s))
+          if ports[expectations[:protocol]][number].has_key?(:address)
+            addresses = ports[expectations[:protocol]][number][:address]
+            addresses.each_key do |address|
+              lr.push(address.eql?(v.to_s))
+            end
+
+            local = ! lr.find{|e| e.true? }.nil? # this feels jankity
+          else
+            # this port isn't open in the first place, won't match any addresses we expect to see it on
+            local = false
           end
-
-          local = ! lr.find{|e| e.true? }.nil? # this feels jankity
-
         else
           raise InternalError.new(sprintf('unknown expectation[%s / %s]', k, v))
       end

--- a/test/unit/testing/test_validate_port.rb
+++ b/test/unit/testing/test_validate_port.rb
@@ -91,6 +91,11 @@ class TestValidatePort < Test::Unit::TestCase
 
   end
 
+  def test_negative_port_dne
+    assert_equal(false, @app.validate_port(4567, { :ensure => true, :address => '*' }))
+    assert_equal(false, @app.validate_port(4567, { :ensure => true, :address => '127.0.0.1' }))
+  end
+
   def teardown
     # noop
   end


### PR DESCRIPTION
  * resolves #89 

there was an error where if the port was not open at all, but had an `:address` specification, we would throw an unexpected exception. the fix fails fast if the port number in question is not in the `ports` hash in the first place