### PR TITLE
CentOS determination fix

### DIFF
--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -315,7 +315,7 @@ class Rouster
 
       end
 
-    elsif os.eql?(:redhat)
+    elsif os.eql?(:rhel)
       raw = self.run('rpm -qa --qf "%{n}@%{v}@%{arch}\n"')
       raw.split("\n").each do |line|
         next if line.match(/(.*?)\@(.*?)\@(.*)/).nil?
@@ -383,7 +383,7 @@ class Rouster
     res = Hash.new()
     os  = self.os_type()
 
-    if os.eql?(:redhat) or os.eql?(:ubuntu) or os.eql?(:debian)
+    if os.eql?(:rhel) or os.eql?(:ubuntu) or os.eql?(:debian)
 
       raw = self.run('netstat -ln')
 
@@ -472,7 +472,7 @@ class Rouster
         :systemv => 'service --status-all 2>&1',
         :upstart => 'initctl list',
       },
-      :redhat => {
+      :rhel => {
         :systemv => '/sbin/service --status-all',
         :upstart => 'initctl list',
       },
@@ -592,7 +592,7 @@ class Rouster
           end
         end
 
-      elsif os.eql?(:redhat)
+      elsif os.eql?(:rhel)
 
         raw.split("\n").each do |line|
           if provider.eql?(:systemv)

--- a/lib/rouster/tests.rb
+++ b/lib/rouster/tests.rb
@@ -380,7 +380,7 @@ class Rouster
       os = self.os_type()
 
       case os
-        when :redhat, :osx, :ubuntu, :debian
+        when :rhel, :osx, :ubuntu, :debian
           res = self.run(sprintf('ps ax | grep -c %s', name))
         else
           raise InternalError.new(sprintf('currently unable to determine running process list on OS[%s]', os))

--- a/test/functional/deltas/test_get_groups.rb
+++ b/test/functional/deltas/test_get_groups.rb
@@ -51,7 +51,7 @@ class TestDeltasGetGroups < Test::Unit::TestCase
     new_group = sprintf('rouster-%s', Time.now.to_i)
 
     ## create a group here
-    if @app.os_type.eql?(:redhat)
+    if @app.os_type.eql?(:rhel)
       @app.run(sprintf('groupadd %s', new_group))
     else
       omit('only doing group creation on RHEL hosts')

--- a/test/functional/deltas/test_get_os.rb
+++ b/test/functional/deltas/test_get_os.rb
@@ -11,7 +11,7 @@ class TestValidateFileFunctional < Test::Unit::TestCase
   FLAG_FILES = {
     :ubuntu  => '/etc/os-release', # debian too
     :solaris => '/etc/release',
-    :redhat  => '/etc/redhat-release', # centos too
+    :rhel    => '/etc/redhat-release', # centos too
     :osx     => '/System/Library/CoreServices/SystemVersion.plist',
   }
 

--- a/test/functional/deltas/test_get_packages.rb
+++ b/test/functional/deltas/test_get_packages.rb
@@ -66,7 +66,7 @@ class TestDeltasGetPackages < Test::Unit::TestCase
     end
 
     # RHEL processing doesn't do anything different in deep/not-deep calls
-    if ! (@app.os_type.eql?(:redhat) or @app.os_type.eql?(:ubuntu))
+    if ! (@app.os_type.eql?(:rhel) or @app.os_type.eql?(:ubuntu))
       res.each_key do |k|
         assert_not_nil(res[k])
         assert_match(/\?/, res[k][:arch])
@@ -101,7 +101,7 @@ class TestDeltasGetPackages < Test::Unit::TestCase
   def test_arch_determination
     after, install = nil, nil
 
-    if @app.os_type.eql?(:redhat)
+    if @app.os_type.eql?(:rhel)
       packages = [ 'glibc.x86_64', 'glibc.i686' ]
       install  = @app.run(sprintf('yum install -y %s', packages.join(' '))) # TODO these are already in the base, but just to be safe
       after    = @app.get_packages(false, false)

--- a/test/functional/test_is_in_file.rb
+++ b/test/functional/test_is_in_file.rb
@@ -1,0 +1,40 @@
+require sprintf('%s/../../path_helper', File.dirname(File.expand_path(__FILE__)))
+
+require 'rouster'
+require 'rouster/tests'
+require 'test/unit'
+
+class TestIsInFile < Test::Unit::TestCase
+
+  SHIBBOLETH = 'foobar'
+
+  def setup
+    assert_nothing_raised do
+      # no reason not to do this as a passthrough once we can
+      @app = Rouster.new(:name => 'app', :sudo => false)
+      @app.up()
+    end
+
+    # create some temporary files
+    @dir_tmp = sprintf('/tmp/rouster-%s.%s', $$, Time.now.to_i)
+    @app.run(sprintf('mkdir %s', @dir_tmp))
+
+    @file = sprintf('%s/file', @dir_tmp)
+    @app.run(sprintf('echo "%s" >> %s', SHIBBOLETH, @file))
+  end
+
+  def teardown; end
+
+  def test_positive
+
+    assert_equal(true, @app.is_in_file?(@file, SHIBBOLETH))
+
+  end
+
+  def test_negative
+
+    assert_equal(false, @app.is_in_file?(@file, 'fizzbuzz'))
+
+  end
+
+end

--- a/test/unit/testing/test_get_services.rb
+++ b/test/unit/testing/test_get_services.rb
@@ -17,7 +17,7 @@ class TestUnitGetPackages < Test::Unit::TestCase
   end
 
   def test_rhel_systemv
-    @app.instance_variable_set(:@ostype, :redhat)
+    @app.instance_variable_set(:@ostype, :rhel)
     services = {}
 
     raw = File.read(sprintf('%s/../../../test/unit/testing/resources/rhel-systemv', File.dirname(File.expand_path(__FILE__))))
@@ -43,7 +43,7 @@ class TestUnitGetPackages < Test::Unit::TestCase
   end
 
   def test_rhel_upstart
-    @app.instance_variable_set(:@ostype, :redhat)
+    @app.instance_variable_set(:@ostype, :rhel)
     services = {}
 
     raw = File.read(sprintf('%s/../../../test/unit/testing/resources/rhel-upstart', File.dirname(File.expand_path(__FILE__))))
@@ -66,7 +66,7 @@ class TestUnitGetPackages < Test::Unit::TestCase
   end
 
   def test_rhel_both
-    @app.instance_variable_set(:@ostype, :redhat)
+    @app.instance_variable_set(:@ostype, :rhel)
     services = {}
 
     systemv_contents  = File.read(sprintf('%s/../../../test/unit/testing/resources/rhel-systemv', File.dirname(File.expand_path(__FILE__))))
@@ -95,7 +95,7 @@ class TestUnitGetPackages < Test::Unit::TestCase
   end
 
   def test_rhel_both_real
-    @app.instance_variable_set(:@ostype, :redhat)
+    @app.instance_variable_set(:@ostype, :rhel)
     services = {}
 
     systemv_contents  = File.read(sprintf('%s/../../../test/unit/testing/resources/rhel-systemv', File.dirname(File.expand_path(__FILE__))))


### PR DESCRIPTION
resolves #93 

  * look at contents of ambiguous files
  * move `:redhat` to `:rhel` to match the contents of `/etc/os-release` on CentOS 7 systems
  * add basic tests for `Rouster#is_in_file?`