### PR TITLE
Rouster.os_version(os_type)

### DIFF
--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -523,7 +523,7 @@ class Rouster
       break unless res.eql?(:invalid)
     end
 
-    @logger.error(sprintf('unable to determine OS, looking for[%s]', files)) if res.eql?(:invalid)
+    @logger.error(sprintf('unable to determine OS, looking for[%s]', Rouster.os_files)) if res.eql?(:invalid)
 
     @ostype = res
     res
@@ -557,12 +557,9 @@ class Rouster
       break unless res.eql?(:invalid)
     end
 
-    @logger.error(sprintf('unable to determine OS version, looking for[%s]', files)) if res.eql?(:invalid)
+    @logger.error(sprintf('unable to determine OS version, looking for[%s]', Rouster.os_files[os_type])) if res.eql?(:invalid)
 
     @osversion = res
-
-    require 'pry'
-    binding.pry
 
     res
   end
@@ -662,9 +659,9 @@ class Rouster
       when :osx
         self.run('shutdown -r now')
       when :rhel, :ubuntu
-        cmd = ((os_type.eql?(:rhel) and os_version(os_type).match(/6/)) or os_type.eql?(:ubuntu)) ? \
-          '/sbin/shutdown -rf now' : \
-          '/sbin/shutdown --halt --reboot now'
+        cmd = (os_type.eql?(:rhel) and os_version(os_type).match(/7/)) ? \
+          '/sbin/shutdown --halt --reboot now' : \
+          '/sbin/shutdown -rf now'
         self.run(cmd)
       when :solaris
         self.run('shutdown -y -i5 -g0')

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -412,11 +412,14 @@ class Rouster
         elsif line.match(/Port (\d*?)$/)
           h[:ssh_port] = $1
         elsif line.match(/IdentityFile (.*?)$/)
-          # TODO this change needs to go in a different branch
           key = $1
-          @logger.info(sprintf('using discovered key[%s] instead of specified key[%s]', key, @sshkey)) unless @sshkey.eql?(key)
-          h[:identity_file] = key
-          @sshkey = key
+
+          unless @sshkey.eql?(key)
+            h[:identity_file] = key
+          else
+            @logger.info(sprintf('using specified key[%s] instead of discovered key[%s]', @sshkey, key))
+            h[:identity_file] = @sshkey
+          end
         end
       end
 
@@ -512,7 +515,7 @@ class Rouster
 
     res = :invalid
 
-    os_files.each_pair do |os, f|
+    Rouster.os_files.each_pair do |os, f|
       [ f ].flatten.each do |candidate|
         if self.is_file?(candidate)
           next if candidate.eql?('/etc/os-release') and ! self.is_in_file?(candidate, os.to_s, 'i') # CentOS detection
@@ -538,7 +541,7 @@ class Rouster
 
     res = :invalid
 
-    [ os_files[os_type] ].flatten.each do |candidate|
+    [ Rouster.os_files[os_type] ].flatten.each do |candidate|
       if self.is_file?(candidate)
         next if candidate.eql?('/etc/os-release') and ! self.is_in_file?(candidate, os_type.to_s, 'i') # CentOS detection
         contents = self.run(sprintf('cat %s', candidate))

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -413,7 +413,6 @@ class Rouster
           h[:ssh_port] = $1
         elsif line.match(/IdentityFile (.*?)$/)
           key = $1
-
           unless @sshkey.eql?(key)
             h[:identity_file] = key
           else
@@ -545,15 +544,16 @@ class Rouster
       if self.is_file?(candidate)
         next if candidate.eql?('/etc/os-release') and ! self.is_in_file?(candidate, os_type.to_s, 'i') # CentOS detection
         contents = self.run(sprintf('cat %s', candidate))
-
         if os_type.eql?(:ubuntu)
-          version = $1 if contents.match(/.*VERSION\="(\d+\.\d+).*"/)
-          res = version # VERSION="13.10, Saucy Salamander"
+          version = $1 if contents.match(/.*VERSION\="(\d+\.\d+).*"/) # VERSION="13.10, Saucy Salamander"
+          res = version unless version.nil?
         elsif os_type.eql?(:rhel)
-          # TODO drop the candidate unless planning to use it
-          version = $1 if contents.match(/.*VERSION\="(\d+)"/)
-          version = $1 if version.nil? and contents.match(/.*(\d+.\d+)/)
-          res = version # VERSION="7 (Core)" or CentOS release 6.4 (Final)
+          version = $1 if contents.match(/.*VERSION\="(\d+)"/) # VERSION="7 (Core)"
+          version = $1 if version.nil? and contents.match(/.*(\d+.\d+)/) # CentOS release 6.4 (Final)
+          res = version unless version.nil?
+        elsif os_type.eql?(:osx)
+          version = $1 if contents.match(/<key>ProductVersion<\/key>.*<string>(.*)<\/string>/m) # <key>ProductVersion</key>\n          <string>10.12.1</string>
+          res = version unless version.nil?
         end
 
       end

--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -76,7 +76,9 @@ class Rouster
       @verbosity_logfile = 2 # this is kind of arbitrary, but won't actually be created unless opts[:logfile] is also passed
     end
 
-    @ostype = nil
+    @ostype    = nil
+    @osversion = nil
+
     @output = Array.new
     @cache  = Hash.new
     @deltas = Hash.new
@@ -410,14 +412,11 @@ class Rouster
         elsif line.match(/Port (\d*?)$/)
           h[:ssh_port] = $1
         elsif line.match(/IdentityFile (.*?)$/)
+          # TODO this change needs to go in a different branch
           key = $1
-          unless @sshkey.eql?(key)
-            h[:identity_file] = key
-          else
-            @logger.info(sprintf('using specified key[%s] instead of discovered key[%s]', @sshkey, key))
-            h[:identity_file] = @sshkey
-          end
-
+          @logger.info(sprintf('using discovered key[%s] instead of specified key[%s]', key, @sshkey)) unless @sshkey.eql?(key)
+          h[:identity_file] = key
+          @sshkey = key
         end
       end
 
@@ -511,16 +510,9 @@ class Rouster
       return @ostype
     end
 
-    files = {
-      :ubuntu  => '/etc/os-release', # debian too
-      :solaris => '/etc/release',
-      :rhel    => ['/etc/os-release', '/etc/redhat-release'], # and centos
-      :osx     => '/System/Library/CoreServices/SystemVersion.plist',
-    }
-
     res = :invalid
 
-    files.each_pair do |os, f|
+    os_files.each_pair do |os, f|
       [ f ].flatten.each do |candidate|
         if self.is_file?(candidate)
           next if candidate.eql?('/etc/os-release') and ! self.is_in_file?(candidate, os.to_s, 'i') # CentOS detection
@@ -534,6 +526,44 @@ class Rouster
     @logger.error(sprintf('unable to determine OS, looking for[%s]', files)) if res.eql?(:invalid)
 
     @ostype = res
+    res
+  end
+
+  ##
+  # os_version
+  #
+  #
+  def os_version(os_type)
+    return @osversion if @osversion
+
+    res = :invalid
+
+    [ os_files[os_type] ].flatten.each do |candidate|
+      if self.is_file?(candidate)
+        next if candidate.eql?('/etc/os-release') and ! self.is_in_file?(candidate, os_type.to_s, 'i') # CentOS detection
+        contents = self.run(sprintf('cat %s', candidate))
+
+        if os_type.eql?(:ubuntu)
+          version = $1 if contents.match(/.*VERSION\="(\d+\.\d+).*"/)
+          res = version # VERSION="13.10, Saucy Salamander"
+        elsif os_type.eql?(:rhel)
+          # TODO drop the candidate unless planning to use it
+          version = $1 if contents.match(/.*VERSION\="(\d+)"/)
+          version = $1 if version.nil? and contents.match(/.*(\d+.\d+)/)
+          res = version # VERSION="7 (Core)" or CentOS release 6.4 (Final)
+        end
+
+      end
+      break unless res.eql?(:invalid)
+    end
+
+    @logger.error(sprintf('unable to determine OS version, looking for[%s]', files)) if res.eql?(:invalid)
+
+    @osversion = res
+
+    require 'pry'
+    binding.pry
+
     res
   end
 
@@ -631,8 +661,11 @@ class Rouster
     case os_type
       when :osx
         self.run('shutdown -r now')
-      when :rhel, :ubuntu, :debian
-        self.run('/sbin/shutdown -rf now')
+      when :rhel, :ubuntu
+        cmd = ((os_type.eql?(:rhel) and os_version(os_type).match(/6/)) or os_type.eql?(:ubuntu)) ? \
+          '/sbin/shutdown -rf now' : \
+          '/sbin/shutdown --halt --reboot now'
+        self.run(cmd)
       when :solaris
         self.run('shutdown -y -i5 -g0')
       else
@@ -781,6 +814,15 @@ class Rouster
     end
 
     nil
+  end
+
+  def self.os_files
+    {
+      :ubuntu  => '/etc/os-release', # debian too
+      :solaris => '/etc/release',
+      :rhel    => ['/etc/os-release', '/etc/redhat-release'], # and centos
+      :osx     => '/System/Library/CoreServices/SystemVersion.plist',
+    }
   end
 
 end


### PR DESCRIPTION
  * add `os_version` method to determine the version of CentOS/RHEL and Debian/Ubuntu systems
  * change `reboot` so that CentOS/RHEL 7 will use `/sbin/shutdown --halt --reboot now`
  * change os_files list to a static method all can use
  * update tests

fixes #97