### PR TITLE
reload =~ restart

### DIFF
--- a/lib/rouster/vagrant.rb
+++ b/lib/rouster/vagrant.rb
@@ -165,9 +165,14 @@ class Rouster
   # runs `vagrant reload <name> [--no-provision]` from the Vagrantfile path
   # +no_provision+ Boolean whether or not to stop reprovisioning
   def reload(no_provision = true)
+
+    if self.is_passthrough?
+      @logger.warn(sprintf('calling [vagrant reload] on a passthrough host is a noop', face))
+      return nil
+    end
+
     @logger.info('reload()')
     self.vagrant(sprintf('reload %s %s', @name, no_provision ? '--no-provision' : ''))
-    disconnect_ssh_tunnel() unless self.is_passthrough?()
   end
 
   ##

--- a/lib/rouster/vagrant.rb
+++ b/lib/rouster/vagrant.rb
@@ -160,6 +160,17 @@ class Rouster
   end
 
   ##
+  # reload
+  #
+  # runs `vagrant reload <name> [--no-provision]` from the Vagrantfile path
+  # +no_provision+ Boolean whether or not to stop reprovisioning
+  def reload(no_provision = true)
+    @logger.info('reload()')
+    self.vagrant(sprintf('reload %s %s', @name, no_provision ? '--no-provision' : ''))
+    disconnect_ssh_tunnel() unless self.is_passthrough?()
+  end
+
+  ##
   # suspend
   #
   # runs `vagrant suspend <name>` from the Vagrantfile path


### PR DESCRIPTION
  * adds `vagrant_reboot` initialization option to allow use of `vagrant reload <vm>` instead of a host-based solution, is called via `restart` if set
  * add `Rouster::Vagrant.reload()` to actually call Vagrant

default behavior remains using a host-based command, and calling this method is a noop on passthrough connections