### PR TITLE
Support `getent group` output in `get_groups()`

### DIFF
--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -150,7 +150,7 @@ class Rouster
     }.each_pair do |source, raw|
 
       raw.split("\n").each do |line|
-        next unless line.match(/\w+:\w+:\w+/)
+        next unless line.match(/\w+:\w*:\w+/)
 
         data = line.split(':')
 


### PR DESCRIPTION
Normal /etc/group lines, at least on Linux hosts, look like:

```
groupname:x:999:possibly-empty-list-o-users
```

However, what you get back using `getent group` can look like:

```
groupname::999:possibly-empty-list-o-users
```

which doesn't match the regex (because there are zero words between those two colons), so all those lines are ignored.

It seems like this change (tweaking the regex to accept zero or more words between the two colons) should be safe: I can't think of a case where it wouldn't be safe, but it'd be good to get your sanity check on that.

I also wasn't sure how best to test this.  As things are now, it seems like you'd need to create a Vagrant instance that uses NIS or something in order to cause `getent` to return a line of the form I'm describing.  As an alternative, I suppose you could tweak the implementation of `get_groups()` to take, I dunno, a default-nil parameter with an array of group-style output strings, like:

```
group_test_data = [
   "unix100:x:100\nunix200:x:200\n",
   "nis100::100\nnis200::200\n",
]
```

and treat those as what's come back from the `cat /etc/group` and `getent group` calls, respectively, assuming the parameter isn't nil. 

So depending on what you think makes sense, I can update this PR to catch this case, just let me know.  My Ruby experience is quite limited so I didn't want to go off the deep end! :)