### PR TITLE
disable password prompts in connect_ssh_tunnel for non-local connections

### DIFF
--- a/lib/rouster.rb
+++ b/lib/rouster.rb
@@ -455,9 +455,10 @@ class Rouster
             @ssh = Net::SSH.start(
               @passthrough[:host],
               @passthrough[:user],
-              :port => @passthrough[:ssh_port],
-              :keys => [ @passthrough[:key] ], # TODO this should be @sshkey
-              :paranoid => false
+              :port                       => @passthrough[:ssh_port],
+              :keys                       => [ @passthrough[:key] ], # TODO this should be @sshkey
+              :paranoid                   => false,
+              :number_of_password_prompts => 0
             )
             break
           rescue => e


### PR DESCRIPTION
We're having an issue when bringing up some centos7 hosts in openstack. There's a race condition where rouster will attempt to ssh into a VM when it's partially up. When it's far enough to allow ssh, but not far enough for the keys to be available (nor far enough for the cloud-init script to disable passwd logins in sshd) our tests stall out on a password prompt.

Considered making this an option, but couldn't envision any use cases where you'd actually want to be manually entering a password there. Originally tried to solve with ":non_interactive => true", but that's not available in older versions of net-ssh (like v2.9.4). ":number_of_password_prompts => 0" accomplishes the same thing and works across versions.