### PR TITLE
Fix handling of usernames with dashes.

### DIFF
--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -772,7 +772,7 @@ class Rouster
     }.each do |source, raw|
 
       raw.split("\n").each do |line|
-        next if line.match(/([\w-]+)(?::\w+){3,}/).nil?
+        next if line.match(/([\w\.-]+)(?::\w+){3,}/).nil?
 
         user = $1
         data = line.split(':')

--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -772,7 +772,7 @@ class Rouster
     }.each do |source, raw|
 
       raw.split("\n").each do |line|
-        next if line.match(/(\w+)(?::\w+){3,}/).nil?
+        next if line.match(/([\w-]+)(?::\w+){3,}/).nil?
 
         user = $1
         data = line.split(':')
@@ -784,11 +784,11 @@ class Rouster
         gid         = data[3]
 
         if res.has_key?(user)
-          @logger.info(sprintf('for[%s] old shell[%s], new shell[%s]', res[user][:shell], shell)) unless shell.eql?(res[user][:shell])
-          @logger.info(sprintf('for[%s] old home[%s], new home[%s]', res[user][:home], home)) unless home.eql?(res[user][:home])
-          @logger.info(sprintf('for[%s] old home_exists[%s], new home_exists[%s]', res[user][:home_exists], home_exists)) unless home_exists.eql?(res[user][:home_exists])
-          @logger.info(sprintf('for[%s] old UID[%s], new UID[%s]', res[user][:uid], uid)) unless uid.eql?(res[user][:uid])
-          @logger.info(sprintf('for[%s] old GID[%s], new GID[%s]', res[user][:gid], gid)) unless gid.eql?(res[user][:gid])
+          @logger.info(sprintf('for[%s] old shell[%s], new shell[%s]', user, res[user][:shell], shell)) unless shell.eql?(res[user][:shell])
+          @logger.info(sprintf('for[%s] old home[%s], new home[%s]', user, res[user][:home], home)) unless home.eql?(res[user][:home])
+          @logger.info(sprintf('for[%s] old home_exists[%s], new home_exists[%s]', user, res[user][:home_exists], home_exists)) unless home_exists.eql?(res[user][:home_exists])
+          @logger.info(sprintf('for[%s] old UID[%s], new UID[%s]', user, res[user][:uid], uid)) unless uid.eql?(res[user][:uid])
+          @logger.info(sprintf('for[%s] old GID[%s], new GID[%s]', user, res[user][:gid], gid)) unless gid.eql?(res[user][:gid])
         end
 
         res[user] = Hash.new()


### PR DESCRIPTION
Regex doesn't handle username with dashes, parsing "alpha-user" and "beta-user" both as "user".  When this happens logging is done, and if "aplha-user" has a different home directory than "beta-user" than rouster crashes because of incorrect number of arguments to sprintf.  Producing a backtrace such as:

```
    /home/centos/rouster/lib/rouster/deltas.rb:788:in `sprintf'
    /home/centos/rouster/lib/rouster/deltas.rb:788:in `block (2 levels) in get_users'
    /home/centos/rouster/lib/rouster/deltas.rb:774:in `each'
    /home/centos/rouster/lib/rouster/deltas.rb:774:in `block in get_users'
    /home/centos/rouster/lib/rouster/deltas.rb:772:in `each'
    /home/centos/rouster/lib/rouster/deltas.rb:772:in `get_users'
    /home/centos/rouster/lib/rouster/testing.rb:722:in `validate_user'
```

The proposed change explicitly allows dashes and fixes the logging statements to prevent crashing.