### PR TITLE
fixing iptables status determination

### DIFF
--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -642,7 +642,7 @@ class Rouster
               elsif line.match(/^(\w+?):.*?\sis\snot\srunning\.$/)
                 # ip6tables: Firewall is not running.
                 res[$1] = 'stopped'
-              elsif line.match(/Chain [A-Z]+ \(policy ACCEPT\)/)
+              elsif line.match(/Chain [A-Z]+ \(policy [A-Z]+\)/)
                 # see https://github.com/chorankates/rouster/issues/84
                 res['iptables'] = 'running'
               elsif line.match(/^(\w+?)\s.*?\s(.*)$/)

--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -642,6 +642,9 @@ class Rouster
               elsif line.match(/^(\w+?):.*?\sis\snot\srunning\.$/)
                 # ip6tables: Firewall is not running.
                 res[$1] = 'stopped'
+              elsif line.match(/Chain [A-Z]+ \(policy ACCEPT\)/)
+                # see https://github.com/chorankates/rouster/issues/84
+                res['iptables'] = 'running'
               elsif line.match(/^(\w+?)\s.*?\s(.*)$/)
                 # netconsole module not loaded
                 state = $2


### PR DESCRIPTION
resolving #84 by detecting iptables output and presuming it is enabled, allowing final line in output to flip to disabled as needed.

relevant iptables information in `service --status-all` when iptables is running:
```
Table: filter       
Chain INPUT (policy ACCEPT)         
num  target     prot opt source               destination
1    ACCEPT     all      ::/0                 ::/0                state RELATED,ESTABLISHED
2    ACCEPT     icmpv6    ::/0                 ::/0
3    ACCEPT     all      ::/0                 ::/0
4    ACCEPT     tcp      ::/0                 ::/0                state NEW tcp dpt:22
5    REJECT     all      ::/0                 ::/0                reject-with icmp6-adm-prohibited
                                
Chain FORWARD (policy ACCEPT)  
num  target     prot opt source               destination
1    REJECT     all      ::/0                 ::/0                reject-with icmp6-adm-prohibited
                
Chain OUTPUT (policy ACCEPT)
num  target     prot opt source               destination
                  
Table: filter       
Chain INPUT (policy ACCEPT)
num  target     prot opt source               destination
1    ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0           state RELATED,ESTABLISHED
2    ACCEPT     icmp --  0.0.0.0/0            0.0.0.0/0
3    ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0
4    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0           state NEW tcp dpt:22
5    REJECT     all  --  0.0.0.0/0            0.0.0.0/0           reject-with icmp-host-prohibited

Chain FORWARD (policy ACCEPT)
num  target     prot opt source               destination
1    REJECT     all  --  0.0.0.0/0            0.0.0.0/0           reject-with icmp-host-prohibited

Chain OUTPUT (policy ACCEPT)
num  target     prot opt source               destination
```

same, when iptables is disabled:
```
Table: filter     
Chain INPUT (policy ACCEPT)
num  target     prot opt source               destination
1    ACCEPT     all      ::/0                 ::/0                state RELATED,ESTABLISHED
2    ACCEPT     icmpv6    ::/0                 ::/0
3    ACCEPT     all      ::/0                 ::/0
4    ACCEPT     tcp      ::/0                 ::/0                state NEW tcp dpt:22
5    REJECT     all      ::/0                 ::/0                reject-with icmp6-adm-prohibited

Chain FORWARD (policy ACCEPT)
num  target     prot opt source               destination
1    REJECT     all      ::/0                 ::/0                reject-with icmp6-adm-prohibited

Chain OUTPUT (policy ACCEPT)
num  target     prot opt source               destination

iptables: Firewall is not running.
```

so now, if the table headers are matched, set iptables to `running`, and if it isn't, we'll catch the final line and flip it back to `stopped`