### PR TITLE
use YAML.load instead of YAML.parse

### DIFF
--- a/lib/rouster/deltas.rb
+++ b/lib/rouster/deltas.rb
@@ -327,7 +327,7 @@ class Rouster
       end
 
     elsif os.eql?(:rhel)
-      raw = self.run('rpm -qa --qf "%{n}@%{v}@%{arch}\n"')
+      raw = self.run('rpm -qa --qf "%{n}@%{v}@%{arch}\n"', 0, false)
       raw.split("\n").each do |line|
         next if line.match(/(.*?)\@(.*?)\@(.*)/).nil?
         name    = $1

--- a/lib/rouster/puppet.rb
+++ b/lib/rouster/puppet.rb
@@ -36,7 +36,7 @@ class Rouster
     res = Hash.new
 
     begin
-      res = YAML.parse(raw)
+      res = YAML.load(raw)
     rescue => e
       raise ExternalError.new(sprintf('unable to parse facter output as YAML[%s], cmd[%s], raw[%s]', e.message, cmd, raw))
     end

--- a/lib/rouster/tests.rb
+++ b/lib/rouster/tests.rb
@@ -36,9 +36,10 @@ class Rouster
     end
 
     begin
-      raw = self.run(sprintf('ls -ld %s', dir))
+      raw  = self.run(sprintf('ls -ld %s', dir)).to_s
+      raw += self.get_ssh_stderr().to_s
     rescue Rouster::RemoteExecutionError
-      raw = self.get_output()
+      raw = self.get_ssh_stdout().to_s + self.get_ssh_stderr().to_s
     end
 
     if raw.match(/No such file or directory/)
@@ -116,7 +117,7 @@ class Rouster
     begin
       raw = self.run(sprintf('ls -l %s', file))
     rescue Rouster::RemoteExecutionError
-      raw = self.get_output()
+      raw = self.get_ssh_stdout()
     end
 
     if raw.match(/No such file or directory/)

--- a/lib/rouster/tests.rb
+++ b/lib/rouster/tests.rb
@@ -117,7 +117,7 @@ class Rouster
     begin
       raw = self.run(sprintf('ls -l %s', file))
     rescue Rouster::RemoteExecutionError
-      raw = self.get_ssh_stdout()
+      raw = self.get_ssh_stdout().to_s + self.get_ssh_stderr().to_s
     end
 
     if raw.match(/No such file or directory/)

--- a/test/functional/test_is_in_file.rb
+++ b/test/functional/test_is_in_file.rb
@@ -20,7 +20,7 @@ class TestIsInFile < Test::Unit::TestCase
     @app.run(sprintf('mkdir %s', @dir_tmp))
 
     @file = sprintf('%s/file', @dir_tmp)
-    @app.run(sprintf('echo "%s" >> %s', SHIBBOLETH, @file))
+    @app.run(sprintf('echo %s >> %s', SHIBBOLETH, @file))
   end
 
   def teardown; end


### PR DESCRIPTION
YAML.load will return a hash, but YAML.parse was returning a Psych::Nodes::Document object. This PR also updates a few usages of .get_output and fixes a couple of spots that were broken after the refactor of .run. The new method does not handle double quotes well if sudo is used and was breaking .get_packages in our tests.